### PR TITLE
feat(17): [사용자] 낙찰자 조회 - 마이페이지

### DIFF
--- a/backEnd/src/main/java/org/example/bidflow/domain/winner/controller/WinnerController.java
+++ b/backEnd/src/main/java/org/example/bidflow/domain/winner/controller/WinnerController.java
@@ -1,9 +1,27 @@
 package org.example.bidflow.domain.winner.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.bidflow.domain.winner.dto.WinnerCheckResponse;
+import org.example.bidflow.domain.winner.service.WinnerService;
+import org.example.bidflow.global.dto.RsData;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
+@RequestMapping("/api/auctions")
 @RequiredArgsConstructor
 public class WinnerController {
+    private final WinnerService winnerService;
+
+    // 낙찰 내역 조회 컨트롤러
+    @GetMapping("/{userUUID}/winner")
+    public ResponseEntity<RsData<List<WinnerCheckResponse>>> getWinnerList(@PathVariable("userUUID") String userUuid) {
+        RsData<List<WinnerCheckResponse>> response = winnerService.getWinnerList(userUuid);
+        return ResponseEntity.status(response.getStatusCode()).body(response);
+    }
 }

--- a/backEnd/src/main/java/org/example/bidflow/domain/winner/dto/WinnerCheckResponse.java
+++ b/backEnd/src/main/java/org/example/bidflow/domain/winner/dto/WinnerCheckResponse.java
@@ -1,0 +1,26 @@
+package org.example.bidflow.domain.winner.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.bidflow.domain.winner.entity.Winner;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class WinnerCheckResponse {
+    private final Long auctionId;
+    private final String productName;
+    private final Integer winningBid;
+    private final LocalDateTime winTime;
+
+    // Winner 엔티티를 낙찰자 조회 응답을 위한 DTO 로 변환
+    public static WinnerCheckResponse from(Winner winner) {
+        return WinnerCheckResponse.builder()
+                .auctionId(winner.getAuction().getAuctionId())
+                .productName(winner.getAuction().getProduct().getProductName())
+                .winningBid(winner.getWinningBid())
+                .winTime(winner.getWinTime())
+                .build();
+    }
+}

--- a/backEnd/src/main/java/org/example/bidflow/domain/winner/repository/WinnerRepository.java
+++ b/backEnd/src/main/java/org/example/bidflow/domain/winner/repository/WinnerRepository.java
@@ -4,6 +4,9 @@ import org.example.bidflow.domain.winner.entity.Winner;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface WinnerRepository extends JpaRepository<Winner, Long> {
+    List<Winner> findByUser_UserUuid(String userUuid);
 }

--- a/backEnd/src/main/java/org/example/bidflow/domain/winner/service/WinnerService.java
+++ b/backEnd/src/main/java/org/example/bidflow/domain/winner/service/WinnerService.java
@@ -1,9 +1,42 @@
 package org.example.bidflow.domain.winner.service;
 
 
+import lombok.RequiredArgsConstructor;
+import org.example.bidflow.domain.winner.dto.WinnerCheckResponse;
+import org.example.bidflow.domain.winner.entity.Winner;
+import org.example.bidflow.domain.winner.repository.WinnerRepository;
+import org.example.bidflow.global.dto.RsData;
+import org.example.bidflow.global.exception.ServiceException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class WinnerService {
+    private final WinnerRepository winnerRepository;
 
+    // 사용자의 낙찰 내역 조회
+    @Transactional(readOnly = true)
+    public RsData<List<WinnerCheckResponse>> getWinnerList(String userUuid) {
+        List<Winner> winners = winnerRepository.findByUser_UserUuid(userUuid);
+
+        // 낙찰자가 존재하지 않을 경우 예외 처리
+        if(winners.isEmpty()){
+            throw new ServiceException("404", "낙찰자가 존재하지 않습니다.");
+        }
+
+        // 낙찰자 목록을 WinnerCheckResponse 로 변환
+        List<WinnerCheckResponse> response = winners.stream()
+                .map(winner -> WinnerCheckResponse.builder()
+                        .auctionId(winner.getAuction().getAuctionId())
+                        .productName(winner.getAuction().getProduct().getProductName())
+                        .winningBid(winner.getWinningBid())
+                        .winTime(winner.getWinTime())
+                        .build())
+                .toList();
+
+        return new RsData<>("200", "낙찰 내역 조회가 완료되었습니다.", response);
+    }
 }


### PR DESCRIPTION
## 🔎 작업 내용
어떤 변경 사항이 있었나요?

- [x] ⚡️ 새로운 기능 추가
- [ ] 🐛버그 수정
- [ ] 💄 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] ♻️️ 코드 리팩토링(성능, 기능 메서드)
- [ ] 📈 주석 추가 및 수정
- [ ] 📝 문서 수정
- [ ] ✅ 테스트 추가, 테스트 리팩토링
- [ ] 🔧 빌드 부분 혹은 패키지 매니저 수정
- [ ] 💚 파일 혹은 폴더명 수정
- [ ] 🔥 파일 혹은 폴더 삭제

### ✏️ 세부 설명 (선택)
- 사용자가 userUuid를 통해 자신이 낙찰한 경매 내역을 조회할 수 있는 기능을 구현

- auctuinId, productName, winnigBid, winTime을 응답.
- 낙찰 내역이 없을 경우 "낙찰자가 존재하지 않습니다." 메시지를 반환
- `userUUID`를 기반으로 낙찰 내역을 조회

### 📷 스크린샷 (선택)

1. 테스트를 위해서 낙찰자 조회를 알아봐야하는데, 제가 데이터 추가를 어떻게 해야할지 몰라서.. ㅎㅎ😅😅
h2에서 직접 Edit을 할 수 있더라구요. 그래서 직접 데이터를 추가해서 테스트를 해봤습니다.
![image](https://github.com/user-attachments/assets/f9573b36-f7a1-4dd8-ae68-7b5abdfadc8f)

2. 테스트 성공 입니다.
![image](https://github.com/user-attachments/assets/a98edbcd-0e47-4d7e-89cf-8f6af46e782d)

3. 테스트 성공 (2회) 입니다.
![image](https://github.com/user-attachments/assets/ca37a925-8346-42f9-ae74-fc9fd076add4)

![image](https://github.com/user-attachments/assets/1536bfb8-887f-4246-aa75-ecc4a1fa835a)

4. 테스트 실패 - 낙찰 내역이 없을 경우 예외 처리입니다.
![image](https://github.com/user-attachments/assets/2f77cf48-215a-4256-8ecb-ee2eec92de2e)

### 추가 개선점
- UUID 와 Uuid 에 대해서 다시 정확한 논의가 필요해보입니다..! 일단 종현님께서 조언해주셔서 Uuid를 쓰는 방향으로 갔습니다 말씀 주셔서 감사합니다!
- WinnerService에서 '낙찰자 목록을 WinnerCheckResponse 로 변환' 하는 메서드에서 스트림 - 빌드를 사용했는데,
뭔가 builder를 남발하는거같기도하고, 이게 괜찮은거 맞나요..? 중복으로 쓰여진건가 싶기도하고 머리 아프네요.. 
편하게 피드백 부탁드립니다!
- Winner Entity에서 오타가 있는 것 같습니다. 추후 리펙토링 과정에 필요해보입니다..! 
일단 충돌 일어날까봐 수정은 안해놨습니다.
![image](https://github.com/user-attachments/assets/5f1cc80d-1961-4373-b1db-d7dc1360d137)

## ➕ 이슈 링크
- [레포 이름 #이슈번호](이슈 주소)

## 📷 스크린샷 (선택)

### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).